### PR TITLE
Fix broken import paths

### DIFF
--- a/app/components/MakeRealButton.tsx
+++ b/app/components/MakeRealButton.tsx
@@ -1,6 +1,6 @@
 import { useEditor, useToasts } from '@tldraw/tldraw'
 import { useCallback } from 'react'
-import { makeReal } from '../makeReal'
+import { makeReal } from '../lib/makeReal'
 
 export function MakeRealButton() {
 	const editor = useEditor()

--- a/app/lib/makeReal.tsx
+++ b/app/lib/makeReal.tsx
@@ -1,8 +1,8 @@
 import { Editor, createShapeId, getSvgAsImage, track } from '@tldraw/tldraw'
-import { getSelectionAsText } from './lib/getSelectionAsText'
-import { getHtmlFromOpenAI } from './lib/getHtmlFromOpenAI'
-import { blobToBase64 } from './lib/blobToBase64'
-import { addGridToSvg } from './lib/addGridToSvg'
+import { getSelectionAsText } from './getSelectionAsText'
+import { getHtmlFromOpenAI } from './getHtmlFromOpenAI'
+import { blobToBase64 } from './blobToBase64'
+import { addGridToSvg } from './addGridToSvg'
 import { PreviewShape } from './PreviewShape/PreviewShape'
 
 export async function makeReal(editor: Editor, apiKey: string) {


### PR DESCRIPTION
- 1063ce3 **Fix broken import paths**

  I think `82c500c` when it was merged in
  `7710e1fcefec1d909ec91ef81c3a830fb5276f64` broke these paths.
  Incidentally, that merge was not rebased before it was merged :'(.
  
  I have another commit that updates the canary used, in the latest canary
  the css packages have been split out and there are some fun looking
  "BaseClass not a Constructor" type errors.
  
  So that is something to look forward to. For now, this commit gets the
  `npm run dev` command up and running again.